### PR TITLE
Limit Extension to Visual Studio Enterprise

### DIFF
--- a/CreateUnitTests.NUnit/Properties/AssemblyInfo.cs
+++ b/CreateUnitTests.NUnit/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Samples.Extensions.NUnit")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © NUnit.org 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/IntelliTest.NUnit/Properties/AssemblyInfo.cs
+++ b/IntelliTest.NUnit/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("NUnit")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © NUnit.org 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/TestGeneration.Extensions.NUnit/Properties/AssemblyInfo.cs
+++ b/TestGeneration.Extensions.NUnit/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/TestGeneration.Extensions.NUnit/source.extension.vsixmanifest
+++ b/TestGeneration.Extensions.NUnit/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="TestGeneration.Extensions.NUnit.113f61ed-a246-4431-809d-bcd393642488" Version="0.9.0" Language="en-US" Publisher="Microsoft, NUnit.Org, Terje Sandstrom" />
-    <DisplayName>Test Generator NUnit extension</DisplayName>
-    <Description xml:space="preserve">Test Generator,  NUnit extensions for Visual Studio 2015.  
+    <Metadata>
+        <Identity Id="TestGeneration.Extensions.NUnit.113f61ed-a246-4431-809d-bcd393642488" Version="0.9.1" Language="en-US" Publisher="Microsoft, NUnit.Org, Terje Sandstrom" />
+        <DisplayName>Test Generator NUnit extension</DisplayName>
+        <Description xml:space="preserve">Test Generator,  NUnit extensions for Visual Studio 2015.  
 Creates Unit tests and Initellitests with both NUnit 2.6.4 and NUnit 3 beta frameworks.
 </Description>
-    <MoreInfo>https://github.com/nunit/nunit-vs-testgenerator/wiki</MoreInfo>
-    <License>license.txt</License>
-    <Icon>nunit3_32x32.png</Icon>
-    <PreviewImage>preview.jpg</PreviewImage>
-    <Tags>unit testing, NUnit</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.IntellitestExtension" d:Source="Project" d:ProjectName="IntelliTest.NUnit" Path="|IntelliTest.NUnit|" />
-    <Asset Type="Microsoft.VisualStudio.TestGenerationExtension" d:Source="Project" d:ProjectName="CreateUnitTests.NUnit" Path="|CreateUnitTests.NUnit|" />
-  </Assets>
+        <MoreInfo>https://github.com/nunit/nunit-vs-testgenerator/wiki</MoreInfo>
+        <License>license.txt</License>
+        <Icon>nunit3_32x32.png</Icon>
+        <PreviewImage>preview.jpg</PreviewImage>
+        <Tags>unit testing, NUnit, IntelliTest</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[14.0]" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.IntellitestExtension" d:Source="Project" d:ProjectName="IntelliTest.NUnit" Path="|IntelliTest.NUnit|" />
+        <Asset Type="Microsoft.VisualStudio.TestGenerationExtension" d:Source="Project" d:ProjectName="CreateUnitTests.NUnit" Path="|CreateUnitTests.NUnit|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
Fixes #2

I updated the VSIX manifest and incremented the version on all assemblies. I cannot test this though since there are no unit tests and I do not own a copy of Visual Studio Enterprise, only Professional.

@OsirisTerje, do you have a copy of Enterprise that you can test on? If Microsoft wants us to maintain this, they should consider some open source software licenses :wink: 

After you test, we may want to push an update to the gallery to prevent users from installing an extension that does nothing and asking more questions like #1.
