### PR TITLE
Specify NUnit 3 vs NUnit 2

### DIFF
--- a/CreateUnitTests.NUnit/CreateUnitTests.NUnit.csproj
+++ b/CreateUnitTests.NUnit/CreateUnitTests.NUnit.csproj
@@ -59,9 +59,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NUnit2FrameworkProvider.cs" />
-    <Compile Include="NUnitFrameworkProvider.cs" />
+    <Compile Include="NUnit3FrameworkProvider.cs" />
     <Compile Include="NUnit2SolutionManager.cs" />
-    <Compile Include="NUnitSolutionManager.cs" />
+    <Compile Include="NUnit3SolutionManager.cs" />
     <Compile Include="NUnitUnitTestClassManager.cs" />
     <Compile Include="NUnitUnitTestProjectManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CreateUnitTests.NUnit/NUnit2SolutionManager.cs
+++ b/CreateUnitTests.NUnit/NUnit2SolutionManager.cs
@@ -39,7 +39,7 @@ namespace TestGeneration.Extensions.NUnit
     {
         private const string NUnitVersion = "2.6.4";
         /// <summary>
-        /// Initializes a new instance of the <see cref="NUnitSolutionManager"/> class.
+        /// Initializes a new instance of the <see cref="NUnit2SolutionManager"/> class.
         /// </summary>
         /// <param name="serviceProvider">The service provider to use to get the interfaces required.</param>
         /// <param name="naming">The naming object used to decide how projects, classes and methods are named and created.</param>

--- a/CreateUnitTests.NUnit/NUnit3FrameworkProvider.cs
+++ b/CreateUnitTests.NUnit/NUnit3FrameworkProvider.cs
@@ -29,28 +29,28 @@ using Microsoft.VisualStudio.TestPlatform.TestGeneration.Model;
 namespace TestGeneration.Extensions.NUnit
 {
     /// <summary>
-    /// The provider for the NUnit 2 unit test framework.
+    /// The provider for the NUnit 3 unit test framework.
     /// </summary>
     [Export(typeof(IFrameworkProvider))]
-    public class NUnitFrameworkProvider : FrameworkProviderBase
+    public class NUnit3FrameworkProvider : FrameworkProviderBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="NUnitFrameworkProvider"/> class.
+        /// Initializes a new instance of the <see cref="NUnit3FrameworkProvider"/> class.
         /// </summary>
         /// <param name="serviceProvider">The service provider to use to get the interfaces required.</param>
         /// <param name="configurationSettings">The configuration settings object to be used to determine how the test method is generated.</param>
         /// <param name="naming">The naming object used to decide how projects, classes and methods are named and created.</param>
         /// <param name="directory">The directory object to use for directory operations.</param>
         [ImportingConstructor]
-        public NUnitFrameworkProvider(IServiceProvider serviceProvider, IConfigurationSettings configurationSettings, INaming naming, IDirectory directory)
-            : base(new NUnitSolutionManager(serviceProvider, naming, directory), new NUnitUnitTestProjectManager(serviceProvider, naming), new NUnitUnitTestClassManager(configurationSettings, naming))
+        public NUnit3FrameworkProvider(IServiceProvider serviceProvider, IConfigurationSettings configurationSettings, INaming naming, IDirectory directory)
+            : base(new NUnit3SolutionManager(serviceProvider, naming, directory), new NUnitUnitTestProjectManager(serviceProvider, naming), new NUnitUnitTestClassManager(configurationSettings, naming))
         {
         }
 
         /// <summary>
         /// Gets the name of the provider.
         /// </summary>
-        public override string Name => "NUnit";
+        public override string Name => "NUnit3";
 
         /// <summary>
         /// Gets the name of the assembly.

--- a/CreateUnitTests.NUnit/NUnit3SolutionManager.cs
+++ b/CreateUnitTests.NUnit/NUnit3SolutionManager.cs
@@ -31,16 +31,16 @@ using VSLangProj80;
 
 namespace TestGeneration.Extensions.NUnit
 {
-    public class NUnitSolutionManager : SolutionManagerBase
+    public class NUnit3SolutionManager : SolutionManagerBase
     {
         private const string NUnit3Version = "3.2.0";
         /// <summary>
-        /// Initializes a new instance of the <see cref="NUnitSolutionManager"/> class.
+        /// Initializes a new instance of the <see cref="NUnit3SolutionManager"/> class.
         /// </summary>
         /// <param name="serviceProvider">The service provider to use to get the interfaces required.</param>
         /// <param name="naming">The naming object used to decide how projects, classes and methods are named and created.</param>
         /// <param name="directory">The directory object to use for directory operations.</param>
-        public NUnitSolutionManager(IServiceProvider serviceProvider, INaming naming, IDirectory directory)
+        public NUnit3SolutionManager(IServiceProvider serviceProvider, INaming naming, IDirectory directory)
             : base(serviceProvider, naming, directory)
         {
         }

--- a/IntelliTest.NUnit/IntelliTest.NUnit.csproj
+++ b/IntelliTest.NUnit/IntelliTest.NUnit.csproj
@@ -56,7 +56,7 @@
   <ItemGroup>
     <Compile Include="NUnit2TestFramework.cs" />
     <Compile Include="NUnitAssertMethodFilter.cs" />
-    <Compile Include="NUnitTestFramework.cs" />
+    <Compile Include="NUnit3TestFramework.cs" />
     <Compile Include="NUnitTestFrameworkMetadata.cs" />
     <Compile Include="NUnitTestFrameworkPackage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/IntelliTest.NUnit/NUnit3TestFramework.cs
+++ b/IntelliTest.NUnit/NUnit3TestFramework.cs
@@ -46,16 +46,16 @@ namespace TestGeneration.Extensions.IntelliTest.NUnit
     /// NUnit 3 test framework
     /// </summary>
     [Serializable]
-    sealed class NUnitTestFramework : AttributeBasedTestFrameworkBase
+    sealed class NUnit3TestFramework : AttributeBasedTestFrameworkBase
     {
         private const string NUnitVersion = "3.2.0";
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NUnitTestFramework"/> class.
+        /// Initializes a new instance of the <see cref="NUnit3TestFramework"/> class.
         /// </summary>
         /// <param name="host">
         /// </param>
-        public NUnitTestFramework(IPexComponent host)
+        public NUnit3TestFramework(IPexComponent host)
             : base(host)
         {
         }
@@ -64,7 +64,7 @@ namespace TestGeneration.Extensions.IntelliTest.NUnit
         /// identify of the test framework
         /// </summary>
         /// <value></value>
-        public override string Name => "NUnit";
+        public override string Name => "NUnit3";
 
         /// <summary>
         /// Gets the assembly name of the framework main's assembly. This name is used

--- a/IntelliTest.NUnit/NUnitAssertMethodFilter.cs
+++ b/IntelliTest.NUnit/NUnitAssertMethodFilter.cs
@@ -28,7 +28,7 @@ using Microsoft.ExtendedReflection.Utilities.Safe.Diagnostics;
 namespace TestGeneration.Extensions.IntelliTest.NUnit
 {
     /// <summary>
-    /// The n unit assert method filer.
+    /// The NUnit assert method filer.
     /// </summary>
     internal sealed class NUnitAssertMethodFilter : IAssertMethodFilter
     {

--- a/IntelliTest.NUnit/NUnitTestFrameworkPackage.cs
+++ b/IntelliTest.NUnit/NUnitTestFrameworkPackage.cs
@@ -48,7 +48,7 @@ namespace TestGeneration.Extensions.IntelliTest.NUnit
             var testFrameworkService = engine.GetService<IPexTestFrameworkManager>();
             var host = testFrameworkService as IPexComponent;
 
-            testFrameworkService.AddTestFramework(new NUnitTestFramework(host));
+            testFrameworkService.AddTestFramework(new NUnit3TestFramework(host));
             testFrameworkService.AddTestFramework(new NUnit2TestFramework(host));
         }
     


### PR DESCRIPTION
Specify the version of NUnit 3 so it's clear which is the latest version for use. Fixes #10 
