### PR TITLE
Update readme and more info link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ or from the [GitHub Releases Page](https://github.com/nunit/nunit-vs-testgenerat
 
 ##Documentation##
 
-Documentation and a Quick Start Guide can be found on the [NUnit Documentation Wiki](https://github.com/nunit/docs/wiki).
+Documentation and a Quick Start Guide can be found on the [NUnit Documentation Wiki](https://github.com/nunit/docs/wiki/Visual-Studio-Test-Generator).

--- a/README.md
+++ b/README.md
@@ -16,15 +16,6 @@ and searching for **Test Generator NUnit Extension**. You can also download from
 [Visual Studio Gallery](https://visualstudiogallery.msdn.microsoft.com/bd30bf3f-4183-4b00-a245-1875316b8cd3) 
 or from the [GitHub Releases Page](https://github.com/nunit/nunit-vs-testgenerator/releases).
 
-##How to Use##
+##Documentation##
 
-For more information on using IntelliTest and this extension, please
-see the [Microsoft documentation](https://msdn.microsoft.com/en-us/library/dn823749.aspx).
-
-###Right-Click to Create Tests###
-
-![Right-Click to Create Tests](https://i-msdn.sec.s-msft.com/dynimg/IC820614.png)
-
-###Select NUnit from the Test Framework dropdown###
-
-![Selecting NUnit](https://i-msdn.sec.s-msft.com/dynimg/IC820617.png)
+Documentation and a Quick Start Guide can be found on the [NUnit Documentation Wiki](https://github.com/nunit/docs/wiki).

--- a/TestGeneration.Extensions.NUnit/source.extension.vsixmanifest
+++ b/TestGeneration.Extensions.NUnit/source.extension.vsixmanifest
@@ -7,6 +7,7 @@
 Creates Unit tests and Intellitests with both NUnit 2.6.4 and NUnit 3 frameworks.
 </Description>
     <MoreInfo>https://github.com/nunit/nunit-vs-testgenerator</MoreInfo>
+    <GettingStartedGuide>https://github.com/nunit/docs/wiki/Visual-Studio-Test-Generator</GettingStartedGuide>
     <License>license.txt</License>
     <Icon>nunit3_32x32.png</Icon>
     <PreviewImage>preview.jpg</PreviewImage>

--- a/TestGeneration.Extensions.NUnit/source.extension.vsixmanifest
+++ b/TestGeneration.Extensions.NUnit/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description xml:space="preserve">Test Generator,  NUnit extensions for Visual Studio 2015.  
 Creates Unit tests and Intellitests with both NUnit 2.6.4 and NUnit 3 frameworks.
 </Description>
-    <MoreInfo>https://github.com/nunit/nunit-vs-testgenerator/wiki</MoreInfo>
+    <MoreInfo>https://github.com/nunit/nunit-vs-testgenerator</MoreInfo>
     <License>license.txt</License>
     <Icon>nunit3_32x32.png</Icon>
     <PreviewImage>preview.jpg</PreviewImage>


### PR DESCRIPTION
Fixes #11 - Update the more information link, and readme to point to the docs wiki where the documentation has now been moved.

The last thing we discussed on #11 was removing the wiki on this repository - would be great if that could be done after merge. (I wondered if we should worry about dead links, but with no wiki it just redirects to the main repo page, and there's a new link to the docs in the readme.)
