### PR TITLE
[Create Unit Test] Fixing package versions

### DIFF
--- a/CreateUnitTests.NUnit/NUnit2SolutionManager.cs
+++ b/CreateUnitTests.NUnit/NUnit2SolutionManager.cs
@@ -38,7 +38,7 @@ namespace TestGeneration.Extensions.NUnit
     public class NUnit2SolutionManager : SolutionManagerBase
     {
         private const string NUnitVersion = "2.6.4";
-        private const string NunitAdapterVersion = "3.13.0";
+        private const string NunitAdapterVersion = "2.2.0";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NUnit2SolutionManager"/> class.

--- a/CreateUnitTests.NUnit/NUnit2SolutionManager.cs
+++ b/CreateUnitTests.NUnit/NUnit2SolutionManager.cs
@@ -38,6 +38,8 @@ namespace TestGeneration.Extensions.NUnit
     public class NUnit2SolutionManager : SolutionManagerBase
     {
         private const string NUnitVersion = "2.6.4";
+        private const string NunitAdapterVersion = "3.13.0";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NUnit2SolutionManager"/> class.
         /// </summary>
@@ -65,7 +67,7 @@ namespace TestGeneration.Extensions.NUnit
 
             base.OnUnitTestProjectCreated(unitTestProject, sourceMethod);
             EnsureNuGetReference(unitTestProject, "NUnit", NUnitVersion);
-            EnsureNuGetReference(unitTestProject, "NUnitTestAdapter", null);
+            EnsureNuGetReference(unitTestProject, "NUnitTestAdapter", NunitAdapterVersion);
 
             var vsp = unitTestProject.Object as VSProject2;
             var reference = vsp?.References.Find(GlobalConstants.MSTestAssemblyName);

--- a/CreateUnitTests.NUnit/NUnit3SolutionManager.cs
+++ b/CreateUnitTests.NUnit/NUnit3SolutionManager.cs
@@ -33,6 +33,9 @@ namespace TestGeneration.Extensions.NUnit
 {
     public class NUnit3SolutionManager : SolutionManagerBase
     {
+        private const string NUnitVersion = "3.12.0";
+        private const string NunitAdapterVersion = "3.13.0";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NUnit3SolutionManager"/> class.
         /// </summary>
@@ -59,8 +62,8 @@ namespace TestGeneration.Extensions.NUnit
             TraceLogger.LogInfo("NUnitSolutionManager.OnUnitTestProjectCreated: Adding reference to NUnit assemblies through nuget.");
 
             base.OnUnitTestProjectCreated(unitTestProject, sourceMethod);
-            this.EnsureNuGetReference(unitTestProject, "NUnit", null);
-            this.EnsureNuGetReference(unitTestProject, "NUnit3TestAdapter", null);
+            this.EnsureNuGetReference(unitTestProject, "NUnit", NUnitVersion);
+            this.EnsureNuGetReference(unitTestProject, "NUnit3TestAdapter", NunitAdapterVersion);
 
             var vsp = unitTestProject.Object as VSProject2;
             var reference = vsp?.References.Find(GlobalConstants.MSTestAssemblyName);

--- a/CreateUnitTests.NUnit/NUnit3SolutionManager.cs
+++ b/CreateUnitTests.NUnit/NUnit3SolutionManager.cs
@@ -34,7 +34,7 @@ namespace TestGeneration.Extensions.NUnit
     public class NUnit3SolutionManager : SolutionManagerBase
     {
         private const string NUnitVersion = "3.12.0";
-        private const string NunitAdapterVersion = "3.13.0";
+        private const string NunitAdapterVersion = "3.15.1";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NUnit3SolutionManager"/> class.


### PR DESCRIPTION
 Adding fixed package versions so that this is similar to the inbox shipped templates. It also ensures compatibility between framework and adapter versions.

This would also ensure that Create Unit Test for .Net Core scenarios just works when a user tries to create an Nunit test project.